### PR TITLE
Add React UI

### DIFF
--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -1,0 +1,51 @@
+function App() {
+    const [messages, setMessages] = React.useState([]);
+    const [newMessage, setNewMessage] = React.useState("");
+
+    const fetchMessages = async () => {
+        const resp = await fetch('/messages');
+        if (resp.ok) {
+            const data = await resp.json();
+            setMessages(data);
+        }
+    };
+
+    React.useEffect(() => {
+        fetchMessages();
+    }, []);
+
+    const saveMessage = async () => {
+        if (!newMessage.trim()) return;
+        const resp = await fetch('/messages', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message: newMessage })
+        });
+        if (resp.ok) {
+            const saved = await resp.json();
+            setMessages([...messages, saved]);
+            setNewMessage("");
+        }
+    };
+
+    return (
+        <div style={{ padding: '1em', fontFamily: 'Arial' }}>
+            <h1>Demo Messages</h1>
+            <ul>
+                {messages.map(m => (
+                    <li key={m.guid}>{m.message}</li>
+                ))}
+            </ul>
+            <input
+                type="text"
+                value={newMessage}
+                onChange={e => setNewMessage(e.target.value)}
+                placeholder="Enter a message"
+            />
+            <button onClick={saveMessage}>Save</button>
+        </div>
+    );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demo Messages</title>
+</head>
+<body>
+    <div id="root"></div>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <script type="text/babel" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add React-based frontend using CDN and Babel
- implement simple UI to list and save messages

## Testing
- `mvn -q test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6885035b6c6c8325bcb12ffde7e4b8d1